### PR TITLE
IOT-6775: Optimize Kafka Read. Avoid blocking on SIGINT

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -15,7 +15,7 @@ jobs:
       - name: Set up Go 1.x
         uses: actions/setup-go@v2
         with:
-          go-version: ^1.14
+          go-version: ^1.17
 
       - uses: actions/checkout@v2
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Set up Go 1.x
         uses: actions/setup-go@v2
         with:
-          go-version: ^1.14
+          go-version: ^1.17
 
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v2

--- a/data/sql/nulls/nulls_test.go
+++ b/data/sql/nulls/nulls_test.go
@@ -4,8 +4,9 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 type Marshaller interface {
@@ -45,6 +46,9 @@ func TestScanFail(t *testing.T) {
 	for _, test := range tests {
 		inst := test.GetInst()
 		err := inst.(sql.Scanner).Scan(test.FailParam)
+		if err == nil {
+			return
+		}
 
 		assert.Error(t, err, fmt.Sprintf("%v shouldnt have error", test.Name))
 		assert.Equal(

--- a/data/sql/nulls/nulls_test.go
+++ b/data/sql/nulls/nulls_test.go
@@ -46,9 +46,6 @@ func TestScanFail(t *testing.T) {
 	for _, test := range tests {
 		inst := test.GetInst()
 		err := inst.(sql.Scanner).Scan(test.FailParam)
-		if err == nil {
-			return
-		}
 
 		assert.Error(t, err, fmt.Sprintf("%v shouldnt have error", test.Name))
 		assert.Equal(

--- a/examples/services/kafka/ingest/index.go
+++ b/examples/services/kafka/ingest/index.go
@@ -9,8 +9,8 @@ import (
 	"github.com/simiancreative/simiango/server"
 	"github.com/simiancreative/simiango/service"
 
+	"github.com/segmentio/kafka-go"
 	kafkago "github.com/segmentio/kafka-go"
-	"github.com/simiancreative/simiango/messaging/kafka"
 )
 
 var writer *kafkago.Writer
@@ -43,6 +43,9 @@ func direct(req service.Req) (interface{}, error) {
 // dont forget to import your package in your main.go for initialization
 // _ "path/to/project/direct"
 func init() {
-	writer = kafka.Writer(os.Getenv("KAFKA_BROKERS"), os.Getenv("KAFKA_READER_TOPIC"))
+	writer = &kafka.Writer{
+		Addr:  kafka.TCP(os.Getenv("KAFKA_BROKERS")),
+		Topic: os.Getenv("KAFKA_READER_TOPIC"),
+	}
 	server.AddService(Config)
 }

--- a/go.mod
+++ b/go.mod
@@ -1,11 +1,10 @@
 module github.com/simiancreative/simiango
 
-go 1.14
+go 1.17
 
 require (
 	github.com/AlecAivazis/survey/v2 v2.2.16
 	github.com/DATA-DOG/go-sqlmock v1.5.0
-	github.com/alicebob/gopher-json v0.0.0-20200520072559-a9ecdc9d1d3a // indirect
 	github.com/alicebob/miniredis v2.5.0+incompatible
 	github.com/aymerick/raymond v2.0.2+incompatible
 	github.com/denisenkom/go-mssqldb v0.9.0
@@ -13,14 +12,12 @@ require (
 	github.com/elliotchance/redismock/v8 v8.5.4
 	github.com/gin-contrib/cors v1.3.1
 	github.com/gin-contrib/pprof v1.3.0
-	github.com/gin-gonic/contrib v0.0.0-20201101042839-6a891bf89f19 // indirect
 	github.com/gin-gonic/gin v1.7.0
 	github.com/go-redis/redis/v8 v8.4.2
 	github.com/go-resty/resty/v2 v2.6.0
 	github.com/go-sql-driver/mysql v1.6.0
 	github.com/golang-jwt/jwt v3.2.2+incompatible
 	github.com/google/uuid v1.1.2
-	github.com/jackc/fake v0.0.0-20150926172116-812a484cc733 // indirect
 	github.com/jackc/pgconn v1.8.0
 	github.com/jackc/pgx v3.6.2+incompatible
 	github.com/jackc/pgx/v4 v4.10.1
@@ -28,10 +25,6 @@ require (
 	github.com/jmoiron/sqlx v1.3.5
 	github.com/joho/godotenv v1.3.0
 	github.com/mandrigin/gin-spa v0.0.0-20200212133200-790d0c0c7335
-	github.com/mattn/go-colorable v0.1.8 // indirect
-	github.com/mattn/go-isatty v0.0.13 // indirect
-	github.com/mattn/go-runewidth v0.0.13 // indirect
-	github.com/mgutz/ansi v0.0.0-20200706080929-d51e80ef957d // indirect
 	github.com/p768lwy3/gin-server-timing v0.0.0-20200316080543-ab69795cf847
 	github.com/prometheus/client_golang v1.12.1
 	github.com/rabbitmq/amqp091-go v1.2.0
@@ -42,10 +35,63 @@ require (
 	github.com/sirupsen/logrus v1.7.0
 	github.com/spf13/cobra v1.2.1
 	github.com/stretchr/testify v1.7.0
-	github.com/ugorji/go v1.1.13 // indirect
-	github.com/yuin/gopher-lua v0.0.0-20200816102855-ee81675732da // indirect
 	golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9
+	gopkg.in/validator.v2 v2.0.0-20200605151824-2b28d334fa05
+)
+
+require (
+	github.com/alicebob/gopher-json v0.0.0-20200520072559-a9ecdc9d1d3a // indirect
+	github.com/beorn7/perks v1.0.1 // indirect
+	github.com/cespare/xxhash/v2 v2.1.2 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect
+	github.com/gin-contrib/sse v0.1.0 // indirect
+	github.com/gin-gonic/contrib v0.0.0-20201101042839-6a891bf89f19 // indirect
+	github.com/go-playground/locales v0.13.0 // indirect
+	github.com/go-playground/universal-translator v0.17.0 // indirect
+	github.com/go-playground/validator/v10 v10.4.1 // indirect
+	github.com/golang-sql/civil v0.0.0-20190719163853-cb61b32ac6fe // indirect
+	github.com/golang/gddo v0.0.0-20200310004957-95ce5a452273 // indirect
+	github.com/golang/protobuf v1.5.2 // indirect
+	github.com/golang/snappy v0.0.1 // indirect
+	github.com/gomodule/redigo v2.0.0+incompatible // indirect
+	github.com/inconshreveable/mousetrap v1.0.0 // indirect
+	github.com/jackc/chunkreader/v2 v2.0.1 // indirect
+	github.com/jackc/fake v0.0.0-20150926172116-812a484cc733 // indirect
+	github.com/jackc/pgio v1.0.0 // indirect
+	github.com/jackc/pgpassfile v1.0.0 // indirect
+	github.com/jackc/pgproto3/v2 v2.0.6 // indirect
+	github.com/jackc/pgservicefile v0.0.0-20200714003250-2b9c44734f2b // indirect
+	github.com/jackc/pgtype v1.6.2 // indirect
+	github.com/json-iterator/go v1.1.12 // indirect
+	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51 // indirect
+	github.com/klauspost/compress v1.9.8 // indirect
+	github.com/leodido/go-urn v1.2.0 // indirect
+	github.com/mattn/go-colorable v0.1.8 // indirect
+	github.com/mattn/go-isatty v0.0.13 // indirect
+	github.com/mattn/go-runewidth v0.0.13 // indirect
+	github.com/matttproud/golang_protobuf_extensions v1.0.1 // indirect
+	github.com/mgutz/ansi v0.0.0-20200706080929-d51e80ef957d // indirect
+	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
+	github.com/modern-go/reflect2 v1.0.2 // indirect
+	github.com/pierrec/lz4 v2.6.0+incompatible // indirect
+	github.com/pkg/errors v0.9.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/prometheus/client_model v0.2.0 // indirect
+	github.com/prometheus/common v0.32.1 // indirect
+	github.com/prometheus/procfs v0.7.3 // indirect
+	github.com/rivo/uniseg v0.2.0 // indirect
+	github.com/spf13/pflag v1.0.5 // indirect
+	github.com/stretchr/objx v0.2.0 // indirect
+	github.com/ugorji/go/codec v1.1.13 // indirect
+	github.com/yuin/gopher-lua v0.0.0-20200816102855-ee81675732da // indirect
+	go.opentelemetry.io/otel v0.14.0 // indirect
+	golang.org/x/net v0.0.0-20210525063256-abc453219eb5 // indirect
+	golang.org/x/sys v0.0.0-20220114195835-da31bd327af9 // indirect
 	golang.org/x/term v0.0.0-20210615171337-6886f2dfbf5b // indirect
 	golang.org/x/text v0.3.7 // indirect
-	gopkg.in/validator.v2 v2.0.0-20200605151824-2b28d334fa05
+	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect
+	google.golang.org/protobuf v1.26.0 // indirect
+	gopkg.in/yaml.v2 v2.4.0 // indirect
+	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
 )

--- a/messaging/kafka/batches.go
+++ b/messaging/kafka/batches.go
@@ -1,12 +1,13 @@
 package kafka
 
 import (
+	"context"
 	"time"
 
 	kafka "github.com/segmentio/kafka-go"
 )
 
-func BatchMessages(values <-chan kafka.Message, maxItems int, maxTimeout time.Duration) chan []kafka.Message {
+func BatchMessages(ctx context.Context, values <-chan kafka.Message, maxItems int, maxTimeout time.Duration) chan []kafka.Message {
 	batches := make(chan []kafka.Message)
 
 	go func() {
@@ -30,7 +31,11 @@ func BatchMessages(values <-chan kafka.Message, maxItems int, maxTimeout time.Du
 
 				case <-expire:
 					goto done
+				case <-ctx.Done():
+					kl.Printf("batch context done")
+					return
 				}
+
 			}
 
 		done:

--- a/messaging/kafka/consumer.go
+++ b/messaging/kafka/consumer.go
@@ -2,14 +2,22 @@ package kafka
 
 import (
 	"context"
+	"math/big"
+	"os"
 	"strings"
+	"sync"
+	"time"
 
 	kafka "github.com/segmentio/kafka-go"
 )
 
-func getKafkaReader(kafkaURL, topic, groupID string) *kafka.Reader {
+func getKafkaReader(kafkaURL string) *kafka.Reader {
 	brokers := strings.Split(kafkaURL, ",")
-	return kafka.NewReader(kafka.ReaderConfig{
+
+	topic := os.Getenv("KAFKA_READER_TOPIC")
+	groupID := os.Getenv("KAFKA_READER_GROUP")
+
+	config := kafka.ReaderConfig{
 		Logger:      kl,
 		StartOffset: kafka.LastOffset,
 		Brokers:     brokers,
@@ -17,44 +25,96 @@ func getKafkaReader(kafkaURL, topic, groupID string) *kafka.Reader {
 		Topic:       topic,
 		MinBytes:    1,    // 1B
 		MaxBytes:    10e6, // 10MB
-	})
+	}
+
+	if minBytes, present := os.LookupEnv("READ_MIN_BYTES"); present {
+		floatVar, _, err := big.ParseFloat(minBytes, 10, 0, big.ToNearestEven)
+		if err != nil {
+			kl.Error("Error converting minBytes to int", fields{"error": err.Error()})
+			return nil
+		}
+		intVar, _ := floatVar.Uint64()
+		config.MinBytes = int(intVar)
+	}
+	if maxBytes, present := os.LookupEnv("READ_MAX_BYTES"); present {
+		floatVar, _, err := big.ParseFloat(maxBytes, 10, 0, big.ToNearestEven)
+		if err != nil {
+			kl.Error("Error converting maxBytes to int", fields{"error": err.Error()})
+			return nil
+		}
+		intVar, _ := floatVar.Uint64()
+		config.MaxBytes = int(intVar)
+	}
+	if maxWait, present := os.LookupEnv("READ_MAX_WAIT_MILLISECONDS"); present {
+		floatVar, _, err := big.ParseFloat(maxWait, 10, 0, big.ToNearestEven)
+		if err != nil {
+			kl.Error("Error converting maxWait to int", fields{"error": err.Error()})
+			return nil
+		}
+		intVar, _ := floatVar.Uint64()
+		config.MaxWait = time.Duration(intVar) * time.Millisecond
+	}
+	if commitInterval, present := os.LookupEnv("READ_COMMIT_INTERVAL"); present {
+		floatVar, _, err := big.ParseFloat(commitInterval, 10, 0, big.ToNearestEven)
+		if err != nil {
+			kl.Error("Error converting maxWait to int", fields{"error": err.Error()})
+			return nil
+		}
+		intVar, _ := floatVar.Uint64()
+		config.CommitInterval = time.Duration(intVar) * time.Millisecond
+	}
+
+	return kafka.NewReader(config)
 }
 
-func NewConsumer(kafkaURL, topic, groupID string, done context.Context) <-chan kafka.Message {
-	reader := getKafkaReader(kafkaURL, topic, groupID)
+func closeReader(reader *kafka.Reader) {
+	kl.Printf("closing reader")
 
-	stop := false
+	if err := reader.Close(); err != nil {
+		kl.Fatal("failed to close reader:", fields{"err": err})
+	}
+}
+
+func NewConsumer(done, sendCtx context.Context, kafkaURL string, wg *sync.WaitGroup) <-chan kafka.Message {
+	reader := getKafkaReader(kafkaURL)
+
 	messages := make(chan kafka.Message)
 
 	go func() {
-		defer close(messages)
-		defer reader.Close()
+		defer func() {
+			kl.Printf("closing consumer...")
+			closeReader(reader)
+			close(messages)
+			kl.Printf("consumer closed, signaling work group...")
+			wg.Done()
+		}()
 
-		select {
-		case <-done.Done():
-			stop = true
-			kl.Printf("closing consumer")
-			return
+		for {
+			m, err := readMessages(done, reader)
+			if err != nil {
+				return
+			}
+			select {
+			case <-done.Done():
+				kl.Printf("done in consumer")
+				return
+			case <-sendCtx.Done():
+				kl.Printf("consumer must stop sending")
+				return
+			case messages <- m:
+			}
 		}
 	}()
-
-	go func() {
-		for !stop {
-			readMessages(reader, messages)
-		}
-	}()
-
 	return messages
 }
 
-func readMessages(reader *kafka.Reader, messages chan kafka.Message) {
-	m, err := reader.ReadMessage(context.Background())
+func readMessages(ctx context.Context, reader *kafka.Reader) (kafka.Message, error) {
+	m, err := reader.ReadMessage(ctx)
 	if err != nil {
 		kl.Error("Error reading message", fields{"err": err.Error()})
-		return
+		return kafka.Message{}, err
 	}
 
-	messages <- m
-
 	kl.Printf("read message (%+v)", MessageSimplified(m))
+	return m, nil
 }

--- a/messaging/kafka/handler.go
+++ b/messaging/kafka/handler.go
@@ -1,31 +1,46 @@
 package kafka
 
 import (
+	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
+	"sync"
 
 	kafka "github.com/segmentio/kafka-go"
 	"github.com/simiancreative/simiango/meta"
 	"github.com/simiancreative/simiango/service"
 )
 
-func buildKafkaMessages(messages service.Messages, out chan<- kafka.Message) {
-	if len(messages) == 0 {
-		return
+func buildKafkaMessages(done, sendCtx context.Context, messages service.Messages, out chan<- kafka.Message) int {
+	msgcnt := len(messages)
+	if msgcnt == 0 {
+		return 0
 	}
 
 	for _, message := range messages {
 		marshalled, _ := json.Marshal(message.Value)
-		out <- kafka.Message{
+		select {
+		case out <- kafka.Message{
 			Key:   []byte(message.Key),
 			Value: marshalled,
+		}:
+		case <-done.Done():
+			kl.Printf("done in handler")
+			return -1
+		case <-sendCtx.Done():
+			// Producer said to stop sending
+			kl.Printf("Handler must stop sending")
+			return -2
 		}
 	}
+	return msgcnt
 }
 
-func Handle(messages <-chan kafka.Message) <-chan kafka.Message {
+func Handle(done, sendCtx context.Context, cancelSend context.CancelFunc, messages <-chan kafka.Message, wg *sync.WaitGroup) <-chan kafka.Message {
 	handlerName := os.Getenv("KAFKA_HANDLER")
+	mustProduce := MustProduce()
 
 	readerConfig, err := findService(handlerName)
 
@@ -37,7 +52,7 @@ func Handle(messages <-chan kafka.Message) <-chan kafka.Message {
 
 	results := make(chan kafka.Message)
 
-	handler := func(message kafka.Message) {
+	handler := func(message kafka.Message) error {
 		requestID := meta.Id()
 
 		defer meta.RescuePanic(requestID, MessageSimplified(message))
@@ -45,28 +60,42 @@ func Handle(messages <-chan kafka.Message) <-chan kafka.Message {
 		service, err := buildService(requestID, readerConfig, message)
 		if err != nil {
 			kl.Error("error building service", fields{"err": err.Error()})
-			return
+			return err
 		}
 
 		if service == nil {
 			kl.Info("no service returned", fields{"message": MessageAsString(message)})
-			return
+			return nil
 		}
 
 		messages, err := service.Result()
 		if err != nil {
 			kl.Error("error on exec result", fields{"err": err.Error()})
-			return
+			return nil // Not going to finish in case of Result errors
 		}
-		buildKafkaMessages(messages, results)
+		if !mustProduce {
+			return nil
+		}
+		if cnt := buildKafkaMessages(done, sendCtx, messages, results); cnt < 0 {
+			return errors.New("stop must stop")
+		}
+
+		return nil
 	}
 
 	go func() {
-		defer close(results)
-		defer kl.Printf("closing handler")
+		defer func() {
+			kl.Printf("closing handler...")
+			cancelSend() // Indicate upstream to stop sending
+			close(results)
+			kl.Printf("handler closed, signaling work group...")
+			wg.Done()
+		}()
 
 		for message := range messages {
-			handler(message)
+			if err := handler(message); err != nil {
+				return
+			}
 		}
 	}()
 

--- a/messaging/kafka/producer.go
+++ b/messaging/kafka/producer.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"strconv"
+	"sync"
 	"time"
 
 	kafka "github.com/segmentio/kafka-go"
@@ -30,14 +31,28 @@ func getBatchSize() int {
 	return size
 }
 
-func getKafkaWriter(kafkaURL, topic string) *kafka.Writer {
-	return &kafka.Writer{
-		Logger:    kl,
-		Addr:      kafka.TCP(kafkaURL),
-		Topic:     topic,
-		Balancer:  &kafka.LeastBytes{},
-		BatchSize: getBatchSize(),
+func GetWriterTopic() string {
+	if topic, present := os.LookupEnv("KAFKA_WRITER_TOPIC"); present {
+		return topic
 	}
+	return ""
+}
+
+func MustProduce() bool {
+	return GetWriterTopic() != ""
+}
+
+func getKafkaWriter(kafkaURL string) *kafka.Writer {
+	if topic := GetWriterTopic(); topic != "" {
+		return &kafka.Writer{
+			Logger:    kl,
+			Addr:      kafka.TCP(kafkaURL),
+			Topic:     topic,
+			Balancer:  &kafka.LeastBytes{},
+			BatchSize: getBatchSize(),
+		}
+	}
+	return nil
 }
 
 func closeWriter(writer *kafka.Writer) {
@@ -48,33 +63,46 @@ func closeWriter(writer *kafka.Writer) {
 	}
 }
 
-func Writer(kafkaURL, topic string) *kafka.Writer {
-	return getKafkaWriter(kafkaURL, topic)
-}
+func NewProducer(done context.Context, cancelSend context.CancelFunc, kafkaURL string, in <-chan kafka.Message, wg *sync.WaitGroup) {
+	writer := getKafkaWriter(kafkaURL)
+	if writer == nil {
+		wg.Done()
+		return
+	}
 
-func NewProducer(kafkaURL, topic string, in <-chan kafka.Message) {
-	writer := getKafkaWriter(kafkaURL, topic)
+	kl.Printf("Producer setup (topic: %v)", writer.Topic)
 
 	go func() {
-		defer closeWriter(writer)
+		batchCtx, batchDone := context.WithCancel(done)
 
-		batches := BatchMessages(in, getBatchSize(), getBatchTimeout())
+		defer func() {
+			kl.Printf("closing producer...")
+			batchDone()  // Indicates batch to stop sending
+			cancelSend() // Indicates upstream to stop sending
+			closeWriter(writer)
+			kl.Printf("producer closed, signaling work group...")
+			wg.Done()
+		}()
+
+		batches := BatchMessages(batchCtx, in, getBatchSize(), getBatchTimeout())
 
 		for messages := range batches {
-			writeMessage(writer, messages)
+			if err := writeMessage(done, writer, messages); err != nil {
+				return
+			}
 		}
 	}()
 }
 
-func writeMessage(writer *kafka.Writer, messages []kafka.Message) {
+func writeMessage(ctx context.Context, writer *kafka.Writer, messages []kafka.Message) error {
 	err := writer.WriteMessages(
-		context.Background(),
+		ctx,
 		messages...,
 	)
 
 	if err != nil {
 		kl.Error("Producer - Failed to write messages", fields{"err": err})
-		return
+		return err
 	}
 
 	kl.Info("Producer - wrote messages to kafka", fields{
@@ -82,4 +110,6 @@ func writeMessage(writer *kafka.Writer, messages []kafka.Message) {
 		"count":    len(messages),
 		"messages": fmt.Sprintf("%+v", MessagesSimplified(messages)),
 	})
+
+	return nil
 }


### PR DESCRIPTION
In this PR:
- Let the module that uses kafka configure the MinBytes, MaxBytes, MaxWait, CommitInterval, instead of hardcoding them in the kafka consumer.
- Give to the kafka reader/writer the proper context, so that when SIGINT is received, they stop reading/writing.
- Give a context to the producer batch so that it stops reading from the handler channel and writing to the batch channel.
- Make sure that when the producer stops for a reason different than closing the handler channel (for example, because of an error in writing a Message to kafka), the producer signals the handler to stop sending messages (so that it does not block).
- Make the handler listen to the stop sending signal from the producer.
- Make sure that when the handler stops processing messages for a reason different than closing the consumer channel (for example, an error in finding the simiango service), the handler indicates the consumer to stop sending.
- Make the consumer listen to the stop sending signal from the handler.